### PR TITLE
feat(consumer-producer):kafka consumer-producer setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ reusable components, and real-world microservice-inspired architectures.
 - vertx-mongo - Vert.x with MongoDB setup
 - springboot-mongo - Spring Boot with MongoDB setup
 - data-mapper - Data Mapping-Unmapping (Marshal-Unamrshal) setup
+- kafka-consumer - Spring Kafka Consumer setup
+- kafka-producer - Spring Kafka Producer setup
 
 ### Github squash commits commands
 Follow the below mentioned steps to squash the commits before merging PR to main branch. Change the parent branch name,
@@ -26,10 +28,38 @@ current branch name, commit message as per the requirement.
 8. git push origin <current_sub-branch_name> -f
 ```
 
-### Wiremock standalone server
-Use the below command to run the wiremock server. If using a different version of wiremock jar, change the version number
-in the command accordingly.
+### Local Infrastructure Setup
+
+- Wiremock standalone server
+  - Download the standalone jar from the link [Download Wiremock Standalone Jar](https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.13.0/wiremock-standalone-3.13.0.jar).
+    Use the below sample command to run the wiremock server. If using a different version of wiremock jar, change the version
+    number in the command accordingly.
 
 ```
 java -jar wiremock-standalone-3.3.1.jar --port 9999
+```
+
+- MongoDB local-instance & Kafka local-instance (Docker instance)
+  - Use the docker-compose.yml file to pull the image & run the MongoDB instance locally on docker.
+  - Use the docker-compose.yml file to pull the image & run the kafka-zookeeper and kafka-server locally on docker. Use the below command.
+
+```
+docker compose up -d
+```
+
+- Kafka local-instance (If not using Docker)
+  - Alternatively, download the kafka binaries from [Download Apache Kafka](https://kafka.apache.org/downloads). Extract the files, then use the below mentioned commands to run the servers.
+
+1. To start the zookeeper
+```
+bin/zookeeper-server-start.sh config/zookeeper.properties
+```
+
+2. To start the kafka server
+```
+bin/server-start.sh config/server.properties
+```
+3. To create the topic on server
+```
+bin/kafka-topics.sh --bootstrap-server localhost:9092 --create --topic <topic-name> --partitions 3 --replication-factor 1
 ```

--- a/apps/code-vault/build.gradle
+++ b/apps/code-vault/build.gradle
@@ -25,6 +25,18 @@ compileJava {
   options.encoding = 'UTF-8'
 }
 
-tasks.named('test') {
-  useJUnitPlatform()
+tasks.withType(JavaCompile).configureEach {
+  enabled = false
+}
+
+tasks.withType(Test).configureEach {
+  enabled = false
+}
+
+tasks.withType(Jar).configureEach {
+  enabled = false
+}
+
+tasks.named("resolveMainClassName") {
+  enabled = false
 }

--- a/apps/kafka-consumer/README.md
+++ b/apps/kafka-consumer/README.md
@@ -1,0 +1,21 @@
+# Kafka Consumer Example POC
+
+### Service Overview
+This service demonstrates a kafka consumer that consumes the messages from a kafka topic using reactive kafka library.
+
+### Tech Stack
+- Java 17
+- Spring Boot
+- Spring Kafka
+- Gradle
+
+Clean build the application.
+
+```shell
+./gradlew clean build
+```
+
+To run the application, add the below configuration to the main application run configuration.
+```
+-Dspring.profiles.active=local
+```

--- a/apps/kafka-consumer/build.gradle
+++ b/apps/kafka-consumer/build.gradle
@@ -1,0 +1,45 @@
+plugins {
+  id 'java'
+  id 'application'
+  id 'tech-engg5.library-conventions'
+}
+
+group = 'com.tech.engg5.kafkaconsumer'
+
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(17)
+  }
+}
+
+configurations {
+  compileOnly {
+    extendsFrom annotationProcessor
+  }
+}
+
+repositories {
+  gradlePluginPortal()
+  mavenCentral()
+}
+
+dependencies {
+  implementation 'org.springframework.boot:spring-boot-starter-webflux:3.1.2'
+  implementation 'org.springframework.kafka:spring-kafka:3.1.1'
+  testImplementation 'org.springframework.kafka:spring-kafka-test:3.1.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+  testImplementation 'org.mockito:mockito-core:5.12.0'
+  testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
+  testImplementation 'io.projectreactor:reactor-test:3.6.4'
+}
+
+test {
+  useJUnitPlatform()
+  testLogging {
+    exceptionFormat = 'full'
+    showStackTraces = true
+    showExceptions = true
+    showCauses = true
+  }
+  finalizedBy jacocoTestReport
+}

--- a/apps/kafka-consumer/src/main/java/com/tech/engg5/kafkaconsumer/KafkaConsumerApplication.java
+++ b/apps/kafka-consumer/src/main/java/com/tech/engg5/kafkaconsumer/KafkaConsumerApplication.java
@@ -1,0 +1,15 @@
+package com.tech.engg5.kafkaconsumer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.kafka.annotation.EnableKafka;
+
+@EnableKafka
+@SpringBootApplication
+public class KafkaConsumerApplication {
+
+  public static void main(String[] args) {
+    SpringApplication application = new SpringApplication(KafkaConsumerApplication.class);
+    application.run(args);
+  }
+}

--- a/apps/kafka-consumer/src/main/java/com/tech/engg5/kafkaconsumer/config/KafkaConsumerConfiguration.java
+++ b/apps/kafka-consumer/src/main/java/com/tech/engg5/kafkaconsumer/config/KafkaConsumerConfiguration.java
@@ -1,0 +1,20 @@
+package com.tech.engg5.kafkaconsumer.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+
+@Configuration
+public class KafkaConsumerConfiguration {
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+    ConsumerFactory<String, String> consumerFactory) {
+    ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    factory.setConsumerFactory(consumerFactory);
+    factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+    return factory;
+  }
+}

--- a/apps/kafka-consumer/src/main/java/com/tech/engg5/kafkaconsumer/service/KafkaConsumerService.java
+++ b/apps/kafka-consumer/src/main/java/com/tech/engg5/kafkaconsumer/service/KafkaConsumerService.java
@@ -1,0 +1,23 @@
+package com.tech.engg5.kafkaconsumer.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class KafkaConsumerService {
+
+  @KafkaListener(topics = "${spring.kafka.consumer.topic}", groupId = "${spring.kafka.consumer.group-id}")
+  public void consumeMessage(ConsumerRecord<String, String> record, Acknowledgment ack) {
+    try {
+      LOG.info("Received message - [{}] from topic - [{}]. Metadata - [Partition: {}, Offset: {}, Key: {}]",
+        record.value(), record.topic(), record.partition(), record.offset(), record.key());
+      ack.acknowledge();
+    } catch (Exception exc) {
+      LOG.error("Error while consuming message.", exc);
+    }
+  }
+}

--- a/apps/kafka-consumer/src/main/resources/application-local.yml
+++ b/apps/kafka-consumer/src/main/resources/application-local.yml
@@ -1,0 +1,6 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: kafka-event-service-group.local
+      topic: employee-event-raw-local

--- a/apps/kafka-consumer/src/main/resources/application.yml
+++ b/apps/kafka-consumer/src/main/resources/application.yml
@@ -1,0 +1,39 @@
+server:
+  port: 8080
+  compression:
+    enabled: true
+  error:
+    include-message: always
+    include-binding-errors: always
+    include-exception: false
+
+management:
+  info:
+    git:
+      enabled: true
+      mode: full
+    endpoints:
+      web:
+        exposure:
+          include: health, info, env
+    endpoint:
+      health:
+        show-components: always
+        show-details: always
+
+logging.level:
+  root: INFO
+  ReportLogger: ERROR
+
+spring:
+  jackson.default-property-inclusion: non_null
+  main.allow-circular-references: true
+  kafka:
+    bootstrap-servers: 'ENTER KAFKA SERVER HOST:PORT'
+    consumer:
+      group-id: 'ENTER CONSUMER GROUP ID'
+      topic: 'ENTER TOPIC NAME'
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/apps/kafka-consumer/src/test/java/com/tech/engg5/kafkaconsumer/service/service/KafkaConsumerServiceTest.java
+++ b/apps/kafka-consumer/src/test/java/com/tech/engg5/kafkaconsumer/service/service/KafkaConsumerServiceTest.java
@@ -1,0 +1,54 @@
+package com.tech.engg5.kafkaconsumer.service.service;
+
+import com.tech.engg5.kafkaconsumer.service.KafkaConsumerService;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class KafkaConsumerServiceTest {
+
+  @InjectMocks
+  private KafkaConsumerService kafkaConsumerService;
+
+  @Mock
+  private ConsumerRecord<String, String> consumerRecord;
+
+  @Mock
+  private Acknowledgment acknowledgment;
+
+  @Test
+  @DisplayName("Verify that message is consumed and acknowledged successfully")
+  void shouldConsumeMessageSuccessfully() {
+    Mockito.when(consumerRecord.value()).thenReturn("test-value");
+    Mockito.when(consumerRecord.topic()).thenReturn("test-topic");
+    Mockito.when(consumerRecord.partition()).thenReturn(0);
+    Mockito.when(consumerRecord.offset()).thenReturn(42L);
+    Mockito.when(consumerRecord.key()).thenReturn("test-key");
+
+    kafkaConsumerService.consumeMessage(consumerRecord, acknowledgment);
+
+    Mockito.verify(acknowledgment, times(1)).acknowledge();
+  }
+
+  @Test
+  @DisplayName("Verify that message consumption throws an exception when acknowledgment fails")
+  void shouldHandleExceptionDuringConsumption() {
+
+    Mockito.when(consumerRecord.value()).thenThrow(new RuntimeException("forced failure"));
+
+    assertDoesNotThrow(() -> kafkaConsumerService.consumeMessage(consumerRecord, acknowledgment));
+
+    Mockito.verify(acknowledgment, never()).acknowledge();
+  }
+}

--- a/apps/kafka-producer/README.md
+++ b/apps/kafka-producer/README.md
@@ -1,0 +1,21 @@
+# Kafka Producer Example POC
+
+### Service Overview
+This service demonstrates a kafka producer that push messages to a kafka topic via a rest endpoint.
+
+### Tech Stack
+- Java 17
+- Spring Boot
+- Spring Kafka
+- Gradle
+
+Clean build the application.
+
+```shell
+./gradlew clean build
+```
+
+To run the application, add the below configuration to the main application run configuration.
+```
+-Dspring.profiles.active=local
+```

--- a/apps/kafka-producer/build.gradle
+++ b/apps/kafka-producer/build.gradle
@@ -1,0 +1,46 @@
+plugins {
+  id 'java'
+  id 'application'
+  id 'tech-engg5.library-conventions'
+}
+
+group = 'com.tech.engg5.kafkaproducer'
+
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(17)
+  }
+}
+
+configurations {
+  compileOnly {
+    extendsFrom annotationProcessor
+  }
+}
+
+repositories {
+  gradlePluginPortal()
+  mavenCentral()
+}
+
+dependencies {
+  implementation 'org.springframework.boot:spring-boot-starter-webflux:3.1.2'
+  implementation 'org.springframework.kafka:spring-kafka:3.1.1'
+  testImplementation 'org.springframework.kafka:spring-kafka-test:3.1.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+  testImplementation 'org.mockito:mockito-core:5.12.0'
+  testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
+  testImplementation 'io.projectreactor:reactor-test:3.6.4'
+  testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+test {
+  useJUnitPlatform()
+  testLogging {
+    exceptionFormat = 'full'
+    showStackTraces = true
+    showExceptions = true
+    showCauses = true
+  }
+  finalizedBy jacocoTestReport
+}

--- a/apps/kafka-producer/src/main/java/com/tech/engg5/kafkaproducer/KafkaProducerApplication.java
+++ b/apps/kafka-producer/src/main/java/com/tech/engg5/kafkaproducer/KafkaProducerApplication.java
@@ -1,0 +1,15 @@
+package com.tech.engg5.kafkaproducer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.kafka.annotation.EnableKafka;
+
+@EnableKafka
+@SpringBootApplication
+public class KafkaProducerApplication {
+
+  public static void main(String[] args) {
+    SpringApplication application = new SpringApplication(KafkaProducerApplication.class);
+    application.run(args);
+  }
+}

--- a/apps/kafka-producer/src/main/java/com/tech/engg5/kafkaproducer/controller/KafkaPublisherController.java
+++ b/apps/kafka-producer/src/main/java/com/tech/engg5/kafkaproducer/controller/KafkaPublisherController.java
@@ -1,0 +1,33 @@
+package com.tech.engg5.kafkaproducer.controller;
+
+import com.tech.engg5.kafkaproducer.service.KafkaPublisherService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/kafka/publisher")
+public class KafkaPublisherController {
+
+  private final KafkaPublisherService kafkaPublisherService;
+
+  public KafkaPublisherController(KafkaPublisherService kafkaPublisherService) {
+    this.kafkaPublisherService = kafkaPublisherService;
+  }
+
+  @PostMapping("/publish-message")
+  public ResponseEntity<String> publishMessage(@RequestBody String request, @RequestParam String key) {
+    LOG.info("Received request to publish message with key: {}", key);
+    try {
+      kafkaPublisherService.publishMessage(request, key);
+      return ResponseEntity.ok("Message published successfully");
+    } catch (Exception e) {
+      return ResponseEntity.status(500).body("Failed to publish message: " + e.getMessage());
+    }
+  }
+}

--- a/apps/kafka-producer/src/main/java/com/tech/engg5/kafkaproducer/service/KafkaPublisherService.java
+++ b/apps/kafka-producer/src/main/java/com/tech/engg5/kafkaproducer/service/KafkaPublisherService.java
@@ -1,0 +1,31 @@
+package com.tech.engg5.kafkaproducer.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class KafkaPublisherService {
+
+  @Value("${spring.kafka.producer.topic}")
+  private String kafkaTopicName;
+
+  private final KafkaTemplate<String, String> kafkaTemplate;
+
+  public KafkaPublisherService(KafkaTemplate<String, String> kafkaTemplate) {
+    this.kafkaTemplate = kafkaTemplate;
+  }
+
+  public void publishMessage(String message, String key) {
+    LOG.info("Inside KafkaPublisherService.publishMessage method. Publishing message - [{}]", message);
+    try {
+      kafkaTemplate.send(kafkaTopicName, key, message);
+      LOG.info("Message published successfully to kafka-topic - [{}]", kafkaTopicName);
+    } catch (Exception exc) {
+      LOG.error("Error publishing message to kafka-topic - [{}]. Error: {}", kafkaTopicName, exc.getMessage(), exc);
+      throw new RuntimeException("Failed to publish message to Kafka topic", exc);
+    }
+  }
+}

--- a/apps/kafka-producer/src/main/resources/application-local.yml
+++ b/apps/kafka-producer/src/main/resources/application-local.yml
@@ -1,0 +1,5 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      topic: employee-event-raw-local

--- a/apps/kafka-producer/src/main/resources/application.yml
+++ b/apps/kafka-producer/src/main/resources/application.yml
@@ -1,0 +1,36 @@
+server:
+  port: 8181
+  compression:
+    enabled: true
+  error:
+    include-message: always
+    include-binding-errors: always
+    include-exception: false
+
+management:
+  info:
+    git:
+      enabled: true
+      mode: full
+    endpoints:
+      web:
+        exposure:
+          include: health, info, env
+    endpoint:
+      health:
+        show-components: always
+        show-details: always
+
+logging.level:
+  root: INFO
+  ReportLogger: ERROR
+
+spring:
+  jackson.default-property-inclusion: non_null
+  main.allow-circular-references: true
+  kafka:
+    bootstrap-servers: 'ENTER KAFKA SERVER HOST:PORT'
+    producer:
+      topic: 'ENTER TOPIC NAME'
+      key-deserializer: org.apache.kafka.common.serialization.StringSerializer
+      value-deserializer: org.apache.kafka.common.serialization.StringSerializer

--- a/apps/kafka-producer/src/test/java/com/tech/engg5/kafkaproducer/controller/KafkaPublisherControllerTest.java
+++ b/apps/kafka-producer/src/test/java/com/tech/engg5/kafkaproducer/controller/KafkaPublisherControllerTest.java
@@ -1,0 +1,60 @@
+package com.tech.engg5.kafkaproducer.controller;
+
+import com.tech.engg5.kafkaproducer.service.KafkaPublisherService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@WebFluxTest(KafkaPublisherController.class)
+public class KafkaPublisherControllerTest {
+
+  @Autowired
+  private WebTestClient webTestClient;
+
+  @MockBean
+  private KafkaPublisherService kafkaPublisherService;
+
+  @Test
+  @DisplayName("Verify that a message is published successfully")
+  void shouldPublishMessageSuccessfully() {
+
+    String request = "Test Kafka Message";
+    String key = "test-key";
+
+    webTestClient.post()
+      .uri(uriBuilder -> uriBuilder.path("/kafka/publisher/publish-message").queryParam("key", key).build())
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(request)
+      .exchange()
+      .expectStatus().isOk()
+      .expectBody(String.class).isEqualTo("Message published successfully");
+
+    verify(kafkaPublisherService).publishMessage(request, key);
+  }
+
+  @Test
+  void shouldReturnErrorWhenPublishingFails() {
+
+    String request = "Invalid message";
+    String key = "fail-key";
+
+    doThrow(new RuntimeException("Kafka error")).when(kafkaPublisherService).publishMessage(request, key);
+
+    webTestClient.post()
+      .uri(uriBuilder -> uriBuilder.path("/kafka/publisher/publish-message").queryParam("key", key).build())
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(request)
+      .exchange()
+      .expectStatus().is5xxServerError()
+      .expectBody(String.class).isEqualTo("Failed to publish message: Kafka error");
+
+    verify(kafkaPublisherService).publishMessage(request, key);
+  }
+}

--- a/apps/kafka-producer/src/test/java/com/tech/engg5/kafkaproducer/service/KafkaPublisherServiceTest.java
+++ b/apps/kafka-producer/src/test/java/com/tech/engg5/kafkaproducer/service/KafkaPublisherServiceTest.java
@@ -1,0 +1,60 @@
+package com.tech.engg5.kafkaproducer.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class KafkaPublisherServiceTest {
+
+  @Mock
+  private KafkaTemplate<String, String> kafkaTemplate;
+
+  @InjectMocks
+  private KafkaPublisherService kafkaPublisherService;
+
+  @BeforeEach
+  void setUp() {
+    // Manually inject the topic value since @Value does not work in unit test
+    ReflectionTestUtils.setField(kafkaPublisherService, "kafkaTopicName", "test-topic");
+  }
+
+  @Test
+  @DisplayName("Verify that message is published to Kafka topic successfully")
+  void shouldPublishMessageSuccessfully() {
+    String key = "test-key";
+    String message = "test-message";
+
+    kafkaPublisherService.publishMessage(message, key);
+
+    verify(kafkaTemplate, times(1)).send("test-topic", key, message);
+  }
+
+  @Test
+  @DisplayName("Verify that exception is thrown when publishing fails")
+  void shouldThrowExceptionWhenPublishingFails() {
+    String key = "fail-key";
+    String message = "fail-message";
+    RuntimeException kafkaException = new RuntimeException("Kafka failure");
+
+    doThrow(kafkaException).when(kafkaTemplate).send("test-topic", key, message);
+
+    RuntimeException thrown = assertThrows(RuntimeException.class, () ->
+      kafkaPublisherService.publishMessage(message, key));
+
+    assertEquals("Failed to publish message to Kafka topic", thrown.getMessage());
+    verify(kafkaTemplate, times(1)).send("test-topic", key, message);
+  }
+}

--- a/apps/springboot-mongo/README.md
+++ b/apps/springboot-mongo/README.md
@@ -13,12 +13,7 @@ CRUD operations on a mongodb collection.
 
 ### Local Setup
 
-To start the application, you need to have MongoDB running locally or provide a connection string to a remove MongoDB
-instance. Use the docker command below to run if using Docker on local.
-
-```shell
-docker compose up -d
-```
+To start the application, refer the root README.md file for instructions.
 
 Clean build the application.
 

--- a/apps/vertx-mongo/README.md
+++ b/apps/vertx-mongo/README.md
@@ -13,12 +13,7 @@ on a MongoDB collection.
 
 ### Local Setup
 
-To start the application, you need to have MongoDB running locally or provide a connection string to a remove MongoDB
-instance. Use the docker command below to run if using Docker on local.
-
-```shell
-docker compose up -d
-```
+To start the application, refer the root README.md file for instructions.
 
 Clean build the application.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,28 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: example
+
+  zookeeper-1:
+    image: confluentinc/cp-zookeeper:latest
+    container_name: zookeeper-1
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - 2181:2181
+
+  kafka-1:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka-1
+    depends_on:
+      - zookeeper-1
+    ports:
+      - 9092:9092
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:9092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'code-notebook'
-include 'apps:code-vault', 'apps:vertx-mongo', 'apps:springboot-mongo', 'apps:data-mapper'
+include 'apps:code-vault', 'apps:vertx-mongo', 'apps:springboot-mongo', 'apps:data-mapper', 'apps:kafka-consumer',
+'apps:kafka-producer'
 


### PR DESCRIPTION
This PR includes the following changes -

- Separate kafka consumer & producer setup.
- Added JUnit test cases.
- Updated root README file with more instructions.
- Updated root docker-compose.yml file for more service images for docker setup.
- Updated code-vault build.gradle file, to skip while running clean build on root project. (FIX)